### PR TITLE
Fix a member name of Subword class on ReazonSpeech NeMo

### DIFF
--- a/source/projects/ReazonSpeech/api/reazonspeech.nemo.asr.rst
+++ b/source/projects/ReazonSpeech/api/reazonspeech.nemo.asr.rst
@@ -186,7 +186,7 @@ reazonspeech.nemo.asr
 
       トークンID
 
-   .. attribute:: text
+   .. attribute:: token
       :type: str
 
       サブワード文字列


### PR DESCRIPTION
From an AWS person

```
お世話になっております。
ReazonSpeechのAPIドキュメントを拝見させていただいていたところ誤植を発見したので報告となります。
下記ドキュメントの Subword クラスに text という変数が定義されていることが説明されていますが、実際のソースコードを確認すると token でした。
https://research.reazon.jp/projects/ReazonSpeech/api/reazonspeech.nemo.asr.html
https://github.com/reazon-research/ReazonSpeech/blob/fac1f39ae9468793ad6fca319f6ddbf3c6c8482c/pkg/nemo-asr/src/interface.py#L17
取り急ぎの報告となりますが、お手隙の際に修正いただければと思います。
```

ref.)
https://github.com/reazon-research/ReazonSpeech/blob/fac1f39ae9468793ad6fca319f6ddbf3c6c8482c/pkg/nemo-asr/src/interface.py#L17